### PR TITLE
fix bug and add Done event

### DIFF
--- a/modules/fastclick-replay-single-mt.testie
+++ b/modules/fastclick-replay-single-mt.testie
@@ -300,4 +300,5 @@ DriverManager(  pause,
                 print "RESULT-COUNT $(add $(RIN/avgA.count) $(RIN/avgB.count) $(RIN/avgC.count) $(RIN/avgD.count) )",
                 print "RESULT-TX $(add $(gen0/avgSIN.link_rate)  $(gen1/avgSIN.link_rate) $(gen2/avgSIN.link_rate) $(gen3/avgSIN.link_rate))",
                 print "RESULT-PPS $(add $(RIN/avgA.rate)  $(RIN/avgB.rate) $(RIN/avgC.rate) $(RIN/avgD.rate))",
+                print "EVENT GEN_DONE",
                 stop);

--- a/modules/fastclick-replay-single.testie
+++ b/modules/fastclick-replay-single.testie
@@ -20,6 +20,7 @@ CLIENT_NIC=0
 TRACE_TIME=8
 LIMIT=200000
 PROMISC=false
+SAMPLE=1
 promisc:PROMISC=true
 
 nolinktest=0
@@ -27,6 +28,7 @@ nolinktest=0
 %late_variables
 NBBUF=EXPAND( $(( ( $LIMIT + ($PKTGEN_BURST_OUT * 2) ) + 8192 )) )
 BROADCAST_IGNORE= -> c :: Classifier(0/$mac,-) //Ignore broadcasts
+NRECORD=EXPAND( $(( $LIMIT / $SAMPLE * $PKTGEN_REPLAY_COUNT  * 2 )) )
 
 %promisc:late_variables
 BROADCAST_IGNORE= -> c :: Classifier(-, 0/ffffffffffff)
@@ -94,7 +96,7 @@ $BROADCAST_IGNORE
 
 receiveIN -> RINswitch :: Switch(2) -> RIN :: Receiver($RAW_INsrcmac,"IN")
 //-> IPPrint(IN)
-  -> Strip(14) -> tsd :: TimestampDiff(rt, N $LIMIT, OFFSET 40) -> Unstrip(14)
+  -> Strip(14) -> tsd :: TimestampDiff(rt, N $NRECORD, OFFSET 40, SAMPLE $SAMPLE) -> Unstrip(14)
 -> avgRIN :: AverageCounter(IGNORE $ignore) -> Discard;
 
 
@@ -166,4 +168,5 @@ DriverManager(  pause,
                 print "Min Delay: $(tsd.min) µs",
                 print "Max Delay: $(tsd.max) µs",
                 print "Delay StdDev: $(tsd.stddev) µs",
+                print "EVENT GEN_DONE",
                 stop);


### PR DESCRIPTION
`SAMPLE` parameter added to the single thread replay.
Also, event `GEN_DONE`  added to both st and mt modules, for being able to do some analysis on DUT side after sending all packets.