### PR TITLE
Label direction and matplotlib renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ This section is in rework.
 ###### Units and name of variables
  * **var_names**, {"result-LATENCY":"Latency (µs)","result-THROUGHPUT":"Throughput"})
  * **var_unit**, {"result": "bps","result-LATENCY":"us","latency":"us","throughput":"bps"})
-  
+
 ###### Plot types
  * **graph_scatter**=true/false Use a scatter plot instead of a lineplot, default false. You must arrange the data so it displays as a line plot (one dynamic variable only).
  * **graph_grid**=true/false Display a grid on the graph. Default false.
@@ -271,6 +271,8 @@ This section is in rework.
  * **graph_legend**=true/false Enable/disable legend. Default is true.
  * **title**=title Title of the graph
  * **var_hide**={A,B,...} List of variables to hide
+ * **var_label_dir**={A:vertical,B:horizontal} Force the direction of labels on the X axis for the given variables. By default, vertical when there are more than 8 values, horizontal otherwise. Accepted values: vertical, horizontal, diagonal
+ * **graph_force_diagonal_labels**=true/false Always use diagonal labels for the X axis, independently from the `var_label_dir` setting. False by default.
  
 
 ##### Data transformation

--- a/npf/grapher.py
+++ b/npf/grapher.py
@@ -1313,9 +1313,9 @@ class Grapher:
                                 else:
                                     base = find_base(ax)
                                 if thresh > 0:
-                                    plt.xscale('symlog',basex=base,linthreshx=thresh )
+                                    plt.xscale('symlog',base=base,linthresh=thresh )
                                 else:
-                                    plt.xscale('log',basex=base)
+                                    plt.xscale('log',base=base)
                                 xticks = data[0][0]
                                 if not is_log(xticks) and xmin:
                                     i = xmin
@@ -1790,7 +1790,7 @@ class Grapher:
             else:
                 thresh=1
             baseLog = float(baseLog[0])
-            plt.yscale('symlog', basey=baseLog, linthreshy=thresh)
+            plt.yscale('symlog', base=baseLog, linthresh=thresh)
             isLog = True
         elif self.result_in_list('var_log', result_type):
             plt.yscale('symlog' if yformat else 'log')

--- a/npf/grapher.py
+++ b/npf/grapher.py
@@ -1551,7 +1551,17 @@ class Grapher:
         rects = plt.bar(ticks, y, label=x, color=c, width=width, yerr=( y - mean + std, mean - y +  std))
 
         self.write_labels(rects, plt,c)
-        plt.xticks(ticks, x, rotation='vertical' if (ndata > 8) else 'horizontal')
+
+        if self.config('graph_force_diagonal_labels'):
+            direction='diagonal'
+        else:
+            direction = self.scriptconfig('var_label_dir', 'result', result_type=result_type, default=None)
+        
+        if direction == 'diagonal' or direction == 'oblique':
+            plt.xticks(ticks, x, rotation = 45, ha='right')
+        else:
+            plt.xticks(ticks, x, rotation = 'vertical' if (ndata > 8 or direction =='vertical') else 'horizontal')
+
         plt.gca().set_xlim(0, len(x))
         return True
 

--- a/npf/section.py
+++ b/npf/section.py
@@ -631,6 +631,8 @@ class SectionConfig(SectionVariable):
         self.__add_list("graph_type", [])
         self.__add("title", None)
         self.__add_list("require_tags", [])
+        self.__add_dict("var_label_dir", {})
+        self.__add("graph_force_diagonal_labels", False)
 
     def var_name(self, key):
         key = key.lower()


### PR DESCRIPTION
Add some options to control the label direction in bar plots, allowing to force diagonal labels.

Also, rename some parameters in matplotlib calls to adapt to versions newer than [3.3.0](https://matplotlib.org/3.3.0/api/api_changes.html#log-symlog-scale-base-ticks-and-nonpos-specification).

This should probably be reflected in the requirements file too.