### PR TITLE
Broken axis and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ This section is in rework.
 ###### Scaling and axis limits
  * **var_log**, [THROUGHPUT,LATENCY] Define variables that should be shown in a log axis in base 2
  * **var_log_base**, {THROUGHPUT:2} Define variables that should be shown in a log axis, with the specified base (default is 2 with var_log)
- * **var_lim**, {THROUGHPUT:0-100} Define the range for some variables, useful to cap graphs. One can produce "broken axis" graphes by giving multiple ranges separated by a + sign. For instance {THROUGHPUT:0-10+50-100}.
+ * **var_lim**, {THROUGHPUT:0-100} Define the range for some variables, useful to cap graphs. One can produce "broken axis" graphes by giving multiple ranges separated by a + sign. For instance {THROUGHPUT:0-10+50-100}. One can also control the ratio between one part and the other by setting a third number after the range: {THROUGHPUT:0-10-20+0-30-100-80} will create a plot where the first range is 20% and the second 80% of the total axis.
  * **var_format**={THROUGHPUT:%dGbps} Printf like formating of va And the prefix should be changed.riables. Eg this example will display all visualisation of the value of throughput (eg in the axis) as XGbps. Use in combination to var_divider.
   * You can also pass `eng` to have an engineering formatting (e.g. 1 k, 2 M, ...).
     Optionally, `eng.2` will print engineering format with 2 decimal places, while `eng.2.Hz` will print e.g. `2.44 kHz`.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ This section is in rework.
  * **var_log_base**, {THROUGHPUT:2} Define variables that should be shown in a log axis, with the specified base (default is 2 with var_log)
  * **var_lim**, {THROUGHPUT:0-100} Define the range for some variables, useful to cap graphs. One can produce "broken axis" graphes by giving multiple ranges separated by a + sign. For instance {THROUGHPUT:0-10+50-100}.
  * **var_format**={THROUGHPUT:%dGbps} Printf like formating of va And the prefix should be changed.riables. Eg this example will display all visualisation of the value of throughput (eg in the axis) as XGbps. Use in combination to var_divider.
+  * You can also pass `eng` to have an engineering formatting (e.g. 1 k, 2 M, ...).
+    Optionally, `eng.2` will print engineering format with 2 decimal places, while `eng.2.Hz` will print e.g. `2.44 kHz`.
  * **var_ticks**, {THROUGHPUT:0+5+10+15+20} Define where the ticks should be set, in this example there will be ticks in 0,5,...20.
 
 ###### Units and name of variables

--- a/integration/broken_axis.npf
+++ b/integration/broken_axis.npf
@@ -1,0 +1,31 @@
+%info
+Use this to test broken axis features:
+~/npf/npf-compare.py local --test broken_axis.npf --config n_runs=1 --no-test --graph-size 6.5 2.5 --tags TAGS
+
+Settings TAGS to a combination of x, y, y_prop, x_prop, both, eng, engHz, engHz3 should change the output
+
+%variables
+
+X=[0-100]
+
+%config
+
+var_lim={}
+var_format={VALUE:%d}
+y:var_lim={VALUE:0-10+30-1000}
+x:var_lim={X:0-10+30-40}
+
+
+yprop:var_lim={VALUE:0-15-3+33-40-6}
+xprop:var_lim={X:0-150-10+100-200-20+250-300-100}
+
+both:var_lim={VALUE:0-15-3+33-40-6+50-60-1,X:0-150-1+100-200-2+250-300}
+
+eng:var_lim={VALUE:0-1500-3+50000-200000-3+5000000-15000000-3}
+
+eng:var_format={VALUE:eng}
+engHz:var_format={VALUE:eng-0-Hz}
+engHz3:var_format={VALUE:eng-3-Hz}
+
+%script
+echo "RESULT-VALUE $(( ($X * $X) ))"

--- a/npf/build.py
+++ b/npf/build.py
@@ -32,7 +32,7 @@ class Build:
         self.n_tests = 0
         self.n_passed = 0
         self.repo = repo
-        self.version = version
+        self.version = str(version)
         self._pretty_name = None
         self._marker = '.'
         self._line = '-'

--- a/npf/grapher.py
+++ b/npf/grapher.py
@@ -1882,9 +1882,22 @@ class Grapher:
             mult = 1024 if unit[0] == "B" else 1000
         axis.set_minor_locator(NullLocator())
         if format:
-            formatter = FormatStrFormatter(format)
-            axis.set_major_formatter(formatter)
-            return True, False
+            # Engineering format as eng+digits+unit
+            if (format.lower().startswith("eng")):
+                digits=None
+                unit = unit
+                f_split= format.split('-')
+                if len(f_split) > 1:
+                    digits=int(f_split[1])
+                    if len(f_split) > 2:
+                        unit = f_split[2]
+                formatter = EngFormatter(places=digits, unit=unit, sep="\N{THIN SPACE}")
+                axis.set_major_formatter(formatter)
+                return True, True
+            else:
+                formatter = FormatStrFormatter(format)
+                axis.set_major_formatter(formatter)
+                return True, False
         elif unit.lower() == "byte":
             axis.set_major_formatter(Grapher.ByteFormatter(unit="B",compact=compact,k=1024,mult=mult))
             return True, True

--- a/npf/grapher.py
+++ b/npf/grapher.py
@@ -1195,8 +1195,8 @@ class Grapher:
                 if nbrokenY * nbrokenX > 1:
                     fig = plt.figure(constrained_layout=False)
 
-                    heights = [ broken_axes_ratio(values) for values in reversed(brokenaxesY)]
-                    widths = [ broken_axes_ratio(values) for values in reversed(brokenaxesX)]
+                    heights = [ broken_axes_ratio(values) for values in brokenaxesY]
+                    widths = [ broken_axes_ratio(values) for values in brokenaxesX]
                     spec = fig.add_gridspec(ncols=nbrokenX, nrows = nbrokenY, height_ratios = heights, width_ratios = widths)
                     spec.update(left=0.15, bottom=0.2)
 

--- a/npf/grapher.py
+++ b/npf/grapher.py
@@ -1102,7 +1102,9 @@ class Grapher:
                 if result is None:
                     continue
                 result_type, lgd, a = result
-                extra_artists += [lgd] + a
+                if lgd is not None:
+                    extra_artists += [lgd]
+                extra_artists += a
 
                 i_subplot += len(figure)
 


### PR DESCRIPTION
The current implementation of broken axis doesn't work when X is broken in multiple segments.
These patches solve that and add support for proportional values for each segment.
For instance, one may want to split the axis at 60%:
var_lim={THROUGHPUT:0-40-60+80-100-40}
The third value of each limit specifies the proportional size.

Engineering format: allows you to have k, M ,... suffixes automatically even when the range of values is big (e.g. when setting a single suffix manually and a divider won't be enough).
 
