### PR TITLE
Multiple pyexit

### DIFF
--- a/integration/imports/.gitignore
+++ b/integration/imports/.gitignore
@@ -1,0 +1,1 @@
+compare/

--- a/integration/imports/main.npf
+++ b/integration/imports/main.npf
@@ -1,0 +1,22 @@
+%config
+default_repo=local //No program under test
+accept_zero={LOG} //Log may be "0" that is a valid number. By default NPF consider a test as failed is a value is 0
+var_unit={RESULT: }
+var_format={RESULT:%d}
+
+%variables
+N=[1-10]
+
+%script
+echo "RESULT-N $N"
+echo "RESULT-LOG $(( log($N) ))"
+echo "RESULT-EXP $(( pow(2,$N) ))"
+
+
+%import module
+
+%pyexit
+print("RESULT_MAIN_PYEXIT 4")
+
+%pyexit  test
+print("RESULT_MAIN_PYEXIT 2")

--- a/integration/imports/modules/module.npf
+++ b/integration/imports/modules/module.npf
@@ -1,0 +1,12 @@
+%script
+echo "RESULT-N $N"
+echo "RESULT-LOG-MODULE $(( log(2*$N) ))"
+echo "RESULT-EXP-MODULE $(( pow(3,$N) ))"
+
+
+%pyexit module1
+print("This is pyexit in module!")
+RESULTS["PYEXIT_MODULE_RESULT1"] = 7
+
+%pyexit module2
+RESULTS["PYEXIT_MODULE_RESULT2"] = 17

--- a/integration/imports/run.sh
+++ b/integration/imports/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+../../npf_compare.py \
+        local \
+        --force-retest \
+        --test main.npf \
+        --result-path results \
+        --config n_runs=1 \
+        --show-cmd \
+        --show-all

--- a/modules/npf.vim
+++ b/modules/npf.vim
@@ -1,0 +1,103 @@
+" Vim syntax file
+" Language: NPF syntax file
+" Maintainer: Massimo Girondi
+" Latest Revision: 10 June 2022
+
+if exists("b:current_syntax")
+  finish
+endif
+
+
+setlocal commentstring=//\ %s
+syntax case match
+
+setlocal iskeyword+=%
+setlocal tabstop=2
+
+
+
+syntax keyword node_kw path user addr tags nfs arch port
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Sections will match in reverse order to handle overlapping names
+syntax match pysections /\v(^\%|\:)\zs(pyexit)\ze( |$|\@)/
+syntax match sections2 /\v(^\%|\:)\zs(|sendfile|late_variables)\ze( |$|\@)/ nextgroup=pysections
+syntax match sections /\v(^\%|\:)\zs(info|config|script|exit|pypost|variables|import|require|file|init)\ze( |$|\@)/ nextgroup=sections2
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+syntax match role /\v\@\zs[a-zA-Z0-9_]+\ze\s/
+syntax match variables /\v\zs[a-zA-Z0-9_]+\ze\+?\??\=/
+" After a tag, look for a section
+syntax match tag /\v(^|,|\%)\zs([a-zA-Z0-9_,|!-]+)\ze(,|:)/ nextgroup=sections
+syntax match comments /^\/\/.*/
+
+
+" Match variables around
+syntax match calledvariables /\v\zs\$\{?[a-zA-Z0-9_]+\}?\ze/
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+syntax include @PYTHON syntax/python.vim
+"syntax include @CLICK syntax/click.vim
+
+" Match inline python code
+syntax match inlineStart /\v\$\(\(/ contained
+syntax match inlineStop /\v\)\)/ contained
+syntax region inlinePy start="\v\$\(\(" end="\v\)\)" contains=@PYTHON,inlineStart,inlineStop,calledvariables transparent keepend
+
+" Match Python regions
+syntax region pyexitRegion start="\v.*pyexit.*" end= "\v\ze^\%" contains=@PYTHON,calledvariables,pysections,comments transparent keepend
+" Try to highlight file with .py in the first line
+syntax region PyScriptRegion start="\v.*(\%|\:)file.*\.py" end="\v\ze^\%" contains=@PYTHON,calledvariables,inlinePy,comments,role,sections,tag transparent keepend
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Bash sections 
+unlet b:current_syntax
+syntax include @SH syntax/bash.vim
+
+" We need to highlight the first line for each section, so we just include
+" parts of it in the contains directive (not the best way thouh...)
+syntax region initRegion start="\v.*(\%|\:)init.*" end="\v\ze^\%" contains=@SH,calledvariables,inlinePy,comments,role,tag,sections transparent keepend
+syntax region scriptRegion start="\v.*(\%|\:)script.*" end="\v\ze^\%" contains=@SH,calledvariables,inlinePy,comments,sections,role,tag transparent keepend
+syntax region exitRegion start="\v.*(\%|\:)exit.*" end="\v\ze^\%" contains=@SH,calledvariables,inlinePy,comments,role,sections,tag transparent keepend
+" Try to highlight file with .sh in the first line
+syntax region bashScriptRegion start="\v.*(\%|\:)file.*\.sh" end="\v\ze^\%" contains=@SH,calledvariables,inlinePy,comments,role,sections,tag transparent keepend
+
+" Match click files (try to when there is a .click extension in the file like)
+unlet b:current_syntax
+syntax include @CLICK syntax/click.vim
+
+syntax region bashScriptRegion start="\v.*(\%|\:)file.*\.click" end="\v\ze^\%" contains=@CLICK,calledvariables,inlinePy,comments,role,sections,tag transparent keepend
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" Handle config sections differently
+
+syntax match configVar /\v\zs[a-zA-Z0-9_]+\ze\+?\??\=/ contained
+syntax match configEntries /\v((\{|,))\zs[a-zA-Z0-9_]+\ze(\:|\,)/
+
+syntax region configRegion start="\v.*(\%|\:)config.*" end="\v\ze^\%" transparent keepend contains=configEntries,tag,comments,configVar,role,sections,configVar,inlinePy
+
+
+
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+highlight default link comments Comment
+highlight default link role ToDo
+highlight tags guifg=green
+highlight role guifg=yellow
+highlight sections guifg=pink cterm=bold
+highlight sections2 guifg=pink cterm=bold
+highlight pysections guifg=pink cterm=bold
+highlight inlineStart guifg=yellow cterm=bold
+highlight inlineStop guifg=yellow cterm=bold
+highlight inline guifg=pink cterm=bold
+highlight default link variables Structure
+highlight tag guifg=aqua
+highlight calledvariables guifg=green
+highlight configRegion guifg=red cterm=bold
+highlight default link configVar Structure
+highlight default link configEntries Storage
+
+" Tell vim that this is npf
+let b:current_syntax = "npf"
+

--- a/npf/section.py
+++ b/npf/section.py
@@ -40,11 +40,12 @@ for sect in known_sections:
 class SectionFactory:
     varPattern = "([a-zA-Z0-9_:-]+)[=](" + Variable.VALUE_REGEX + ")?"
     namePattern = re.compile(
-        "^(?P<tags>" + Variable.TAGS_REGEX + "[:])?(?P<name>info|config|variables|exit|pypost|pyexit|late_variables|include (?P<includeName>[a-zA-Z0-9_./-]+)(?P<includeParams>([ \t]+" +
+        "^(?P<tags>" + Variable.TAGS_REGEX + "[:])?(?P<name>info|config|variables|exit|pypost|late_variables|include (?P<includeName>[a-zA-Z0-9_./-]+)(?P<includeParams>([ \t]+" +
         varPattern + ")+)?|(init-)?file(:?[@](?P<fileRole>[a-zA-Z0-9]+))? (?P<fileName>[a-zA-Z0-9_.-]+)(:? (?P<fileNoparse>noparse))?|require|"
                                              "import(:?[@](?P<importRole>[a-zA-Z0-9]+)(:?[-](?P<importMulti>[*0-9]+))?)?[ \t]+(?P<importModule>" + Variable.VALUE_REGEX + ")(?P<importParams>([ \t]+" +
         varPattern + ")+)?|" +
                      "sendfile(:?[@](?P<sendfileRole>[a-zA-Z0-9]+))?[ \t]+(?P<sendfilePath>.*)|" +
+                     "pyexit(?P<PyExitName>.*)|"
                      "(:?script|init|exit)(:?[@](?P<scriptRole>[a-zA-Z0-9]+)(:?[-](?P<scriptMulti>[*0-9]+))?)?(?P<scriptParams>([ \t]+" + varPattern + ")*))$")
 
     @staticmethod
@@ -93,6 +94,11 @@ class SectionFactory:
 
             return s
 
+        if sectionName.startswith('pyexit'):
+            name = matcher.group("PyExitName").strip()
+            s = SectionPyExit(name)
+            return s
+
         if matcher.group('scriptParams') is not None:
             raise Exception("Only script sections takes arguments (" + sectionName + " has argument " +
                             matcher.groups("params") + ")")
@@ -121,8 +127,6 @@ class SectionFactory:
 
         if sectionName == 'variables':
             s = SectionVariable()
-        elif sectionName == 'pyexit':
-            s = Section('pyexit')
         elif sectionName == 'pypost':
             s = Section('pypost')
         elif sectionName == 'exit':
@@ -220,6 +224,24 @@ class SectionScript(Section):
         for dep in self.params["deps"].split(","):
             deps.add(dep)
         return deps
+
+class SectionPyExit(Section):
+    num = 0
+
+    def __init__(self, name = ""):
+        super().__init__('pyexit')
+        self.index = ++self.num
+        self.name = name
+
+    def finish(self, testie):
+        testie.pyexits.append(self)
+
+    def get_name(self, full=False):
+        if self.name != "":
+            return "pyexit_"+str(self.index)
+        else:
+            return "pyexit_"+self.name
+
 
 
 class SectionImport(Section):

--- a/npf/testie.py
+++ b/npf/testie.py
@@ -841,7 +841,7 @@ class Testie:
                 all_pyexits = []
                 all_pyexits_v = []
                 for s,vlist in [(t.testie,t.imp_v) for t in self.imports] + [(self, v)]:
-                    for p in s.get_pyexits():
+                    for p in sorted(s.get_pyexits()):
                         all_pyexits.append(p)
                         all_pyexits_v.append(vlist)
 

--- a/npf/testie.py
+++ b/npf/testie.py
@@ -839,17 +839,24 @@ class Testie:
 
 
                 all_pyexits = []
+                all_pyexits_v = []
                 for s,vlist in [(t.testie,t.imp_v) for t in self.imports] + [(self, v)]:
                     for p in s.get_pyexits():
                         all_pyexits.append(p)
+                        all_pyexits_v.append(vlist)
 
                 if len(all_pyexits) >0 and allowed_types != set([SectionScript.TYPE_INIT]):
                     vs = {'RESULTS': new_data_results, 'TIME_RESULTS': new_kind_results["time"], 'KIND_RESULTS':new_kind_results}
                     vs.update(v)
+
+                    for late_variables in self.get_late_variables():
+                        vs.update(late_variables.execute(vs, self, fail=False))
+
                     try:
-                        for p in all_pyexits:
+                        for p,v in zip(all_pyexits, all_pyexits_v):
                             print("Executing PyExit script", p.name)
-                            exec(p.content, vs)
+                            v.update(vs)
+                            exec(p.content, v)
                     except SystemExit as e:
                         if e.code != 0:
                             print("ERROR WHILE EXECUTING PYEXIT SCRIPT: returned code %d" % e.code)

--- a/npf/testie.py
+++ b/npf/testie.py
@@ -111,6 +111,7 @@ class Testie:
         return self.scripts
 
     def get_pyexits(self) -> List[SectionPyExit]:
+        self.pyexits.sort(key=lambda p: f"{p.name}_{p.index}")
         return self.pyexits
 
     def __init__(self, testie_path, options, tags=None, role=None, inline=None):
@@ -841,7 +842,7 @@ class Testie:
                 all_pyexits = []
                 all_pyexits_v = []
                 for s,vlist in [(t.testie,t.imp_v) for t in self.imports] + [(self, v)]:
-                    for p in sorted(s.get_pyexits()):
+                    for p in s.get_pyexits():
                         all_pyexits.append(p)
                         all_pyexits_v.append(vlist)
 


### PR DESCRIPTION
This is not completely finished yet, but let's start tracking the pending changes.

One may want to have multiple pyexit sections that are called when importing modules or when certain tags are given.
For instance, one may have a post processing pyexit that should be executed only some times.
It was not possible to do that in NPF (AFAIK).

Also, includes late_variables when running pyexit even in imported modules, otherwise it is not possible to access them. Pyexits are now executed in alphabetical order so one can have for instance "00-preprocess", ..., "99-averages", where in the last it calculated all the averages of the variables created/changed in the previous steps (useful if you want e.g. percentiles of time metrics). _This functionality is not completely tested yet._

Finally, an initial version of a VIM syntax highlight for npf files.