### PR TITLE
Add option --use-openssh-config to use connection parameters from the…

### DIFF
--- a/npf/node.py
+++ b/npf/node.py
@@ -170,19 +170,21 @@ class Node:
         return node
 
     @classmethod
-    def makeSSH(cls, user, addr, path, options, port=22, nfs=None):
+    def makeSSH(cls, user, addr, path, options, port=22, nfs=None, use_openssh_config=False):
         if path is None:
             path = os.path.abspath(npf.experiment_path())
         node = cls._nodes.get(addr, None)
         if node is not None:
             return node
-        sshex = SSHExecutor(user, addr, path, port)
+        sshex = SSHExecutor(user, addr, path, port, use_openssh_config=use_openssh_config)
         node = Node(addr, sshex, options.tags)
         if nfs is not None:
             node.nfs = nfs
         cls._nodes[addr] = node
 
-        if options.do_test and options.do_conntest:
+        if options.do_test and options.do_conntest: #disable conn test for opensshconfigs
+            if use_openssh_config:
+                print("When using --use-openssh-config, please disable connection tests !")
             try:
                 node.ip = socket.gethostbyname(node.executor.addr)
             except Exception as e:

--- a/npf/npf.py
+++ b/npf/npf.py
@@ -173,6 +173,7 @@ def add_testing_options(parser: ArgumentParser, regression: bool = False):
     t.add_argument('--experimental-design', type=str, default="matrix.csv", help="The path towards the experimental design point selection file")
 
     c = parser.add_argument_group('Cluster options')
+    c.add_argument('--use-openssh-config', action='store_true', help="Parse and use the openssh config file in /home/<user>/.ssh/config", default=False)
     c.add_argument('--cluster', metavar='role=user@address:path [...]', type=str, nargs='*', default=[],
                    help='role to node mapping for remote execution of tests. The format is role=address, where address can be an address or a file in cluster/address.node describing supplementary parameters for the node.')
     c.add_argument('--cluster-autosave', default=False, action='store_true', dest='cluster_autosave',
@@ -310,7 +311,7 @@ def parse_nodes(args):
             node = local
         else:
             node = Node.makeSSH(user=match.group('user'), addr=match.group('addr'), path=path,
-                            options=options, nfs=nfs)
+                            options=options, nfs=nfs, use_openssh_config=args.use_openssh_config)
         role = match.group('role')
         if role in roles:
             roles[role].append(node)

--- a/npf_run.py
+++ b/npf_run.py
@@ -4,6 +4,7 @@ Main NPF test runner program
 """
 import argparse
 import errno
+import os
 
 import sys
 
@@ -63,7 +64,11 @@ def main():
     parser.add_argument('repo', metavar='repo name', type=str, nargs='?', help='name of the repo/group of builds', default=None)
 
     args = parser.parse_args()
-
+    if args.use_openssh_config:
+        openssh_conf_path = os.path.join(os.getenv("HOME"), ".ssh", "config")
+        if not os.path.exists(openssh_conf_path):
+            print(f"Could not find a openssh config: {openssh_conf_path}")
+            del args.use_openssh_config
 
     npf.parse_nodes(args)
 


### PR DESCRIPTION
This pull request adds an option to use ssh jumps specified within a openssh config file located at $HOME/.ssh/config. To use this option you must also use the --no-conntest  option for now.