### PR TITLE
Database escape fix

### DIFF
--- a/npf/build.py
+++ b/npf/build.py
@@ -200,7 +200,8 @@ class Build:
         filename = self.__resultFilename()
         if not os.path.exists(os.path.dirname(filename)):
             os.makedirs(os.path.dirname(filename))
-        open(filename, 'a').close()
+        
+        open(filename, 'w').close()
 
     def build_path(self):
         return self.repo.get_build_path()

--- a/npf/build.py
+++ b/npf/build.py
@@ -116,7 +116,7 @@ class Build:
             for key, val in sorted(run.variables.items()):
                 if type(val) is tuple:
                     val = val[1]
-                v.append((key + ":" + str(val).replace(':','\:')).replace(',','\,'))
+                v.append((key + ":" + str(val).replace('\:', ':').replace(':','\:')).replace('\,', ',').replace(',','\,'))
             type_results = []
             for t,r in results.items():
                 str_results = []


### PR DESCRIPTION
When the experiments results are saved to a file, some characters are escaped using this character: '\'
Unfortunately, it is escaped each time a new record is written to the results file.
This would result in a results file getting much more bigger and less readable than it should be.
These commits fix this by removing the '\' characters first if needed.