### PR TITLE
Minor assertion verifying that no variable has an "=" in its values.

### DIFF
--- a/npf/test.py
+++ b/npf/test.py
@@ -175,6 +175,10 @@ class Test:
                 elif section is None:
                     raise Exception("Bad syntax, file must start by a section. Line %d :\n%s" % (i, line))
                 else:
+                    if section.name == "variables":  # if the current section is "variables"
+                        # then the variable assigned to a value may not contain any '='
+                        assert '=' not in line[line.find('=') + 1:], (f"Variables values cannot include a '=' character"
+                                                                      f". Please correct this line: {line[:-1]}.")
                     section.content += line
             f.close()
 


### PR DESCRIPTION
This is a minor assertion verifying that no variable has an "=" in its values.
It changes almost nothing, but might save to others the time it took to me to understand the problem while I was using NPF giving it values as "CFLAGS=-DNAIVE=1", making it constantly crash.
For example, this:
```
%variables
PARAM=[1-3]
```
would be fully valid, as this:
```
%variables
PARAM={a=1,a=2,a=3}
```
would throw an exception.