### PR TITLE
Jinja support

### DIFF
--- a/npf/section.py
+++ b/npf/section.py
@@ -41,12 +41,13 @@ for sect in known_sections:
 class SectionFactory:
     varPattern = "([a-zA-Z0-9_:-]+)[=](" + Variable.VALUE_REGEX + ")?"
     namePattern = re.compile(
-        "^(?P<tags>" + Variable.TAGS_REGEX + "[:])?(?P<name>info|config|variables|exit|pypost|pyexit|late_variables|include (?P<includeName>[a-zA-Z0-9_./-]+)(?P<includeParams>([ \t]+" +
-        varPattern + ")+)?|(init-)?file(:?[@](?P<fileRole>[a-zA-Z0-9]+))? (?P<fileName>[a-zA-Z0-9_.${}-]+)(:? (?P<fileNoparse>noparse))?|require|"
-                                             "import(:?[@](?P<importRole>[a-zA-Z0-9]+)(:?[-](?P<importMulti>[*0-9]+))?)?[ \t]+(?P<importModule>" + Variable.VALUE_REGEX + ")(?P<importParams>([ \t]+" +
-        varPattern + ")+)?|" +
-                     "sendfile(:?[@](?P<sendfileRole>[a-zA-Z0-9]+))?[ \t]+(?P<sendfilePath>.*)|" +
-                     "(:?script|init|exit)(:?[@](?P<scriptRole>[a-zA-Z0-9]+)(:?[-](?P<scriptMulti>[*0-9]+))?)?(?P<scriptParams>([ \t]+" + varPattern + ")*))$")
+        "^(?P<tags>" + Variable.TAGS_REGEX + "[:])?(?P<name>info|config|variables|exit|pypost|pyexit|late_variables|"
+        "include (?P<includeName>[a-zA-Z0-9_./-]+)(?P<includeParams>([ \t]+" + varPattern + ")+)?|"
+        "(init-)?file(:?[@](?P<fileRole>[a-zA-Z0-9]+))? (?P<fileName>[a-zA-Z0-9_.${}-]+)(:? (?P<fileNoparse>noparse))?(:? (?P<fileJinja>jinja))?|"
+        "require|"
+        "import(:?[@](?P<importRole>[a-zA-Z0-9]+)(:?[-](?P<importMulti>[*0-9]+))?)?[ \t]+(?P<importModule>" + Variable.VALUE_REGEX + ")(?P<importParams>([ \t]+" + varPattern + ")+)?|"
+        "sendfile(:?[@](?P<sendfileRole>[a-zA-Z0-9]+))?[ \t]+(?P<sendfilePath>.*)|" +
+        "(:?script|init|exit)(:?[@](?P<scriptRole>[a-zA-Z0-9]+)(:?[-](?P<scriptMulti>[*0-9]+))?)?(?P<scriptParams>([ \t]+" + varPattern + ")*))$")
 
     @staticmethod
     def build(test, data):
@@ -100,7 +101,7 @@ class SectionFactory:
 
         if sectionName.startswith('file'):
             s = SectionFile(matcher.group('fileName').strip(), role=matcher.group('fileRole'),
-                            noparse=matcher.group('fileNoparse'))
+                            noparse=matcher.group('fileNoparse'), jinja=matcher.group('fileJinja'))
             return s
         if sectionName.startswith('init-file'):
             s = SectionInitFile(matcher.group('fileName').strip(), role=matcher.group('fileRole'),
@@ -257,12 +258,13 @@ class SectionImport(Section):
 
 
 class SectionFile(Section):
-    def __init__(self, filename, role=None, noparse=False):
+    def __init__(self, filename, role=None, noparse=False, jinja=False):
         super().__init__('file')
         self.content = ''
         self.filename = filename
         self._role = role
         self.noparse = noparse
+        self.jinja = jinja
 
     def get_role(self):
         return self._role

--- a/npf/test.py
+++ b/npf/test.py
@@ -405,6 +405,14 @@ class Test:
             if not s.noparse:
                 s.filename = SectionVariable.replace_variables(v, s.filename, role, default_role_map = self.config.get_dict("default_role_map"))
                 p = SectionVariable.replace_variables(v, s.content, role,default_role_map = self.config.get_dict("default_role_map"))
+                if s.jinja:
+                    from jinja2 import Environment, PackageLoader, select_autoescape
+                    env = Environment(
+                        loader=PackageLoader("npf"),
+                        autoescape=select_autoescape()
+                    )
+                    template = env.from_string(p)
+                    p = template.render(**v)
             else:
                 p = s.content
             create_list.append((s.filename, p, role))

--- a/npf/test.py
+++ b/npf/test.py
@@ -405,16 +405,13 @@ class Test:
             if not s.noparse:
                 s.filename = SectionVariable.replace_variables(v, s.filename, role, default_role_map = self.config.get_dict("default_role_map"))
                 p = SectionVariable.replace_variables(v, s.content, role,default_role_map = self.config.get_dict("default_role_map"))
-                if s.jinja:
-                    from jinja2 import Environment, PackageLoader, select_autoescape
-                    env = Environment(
-                        loader=PackageLoader("npf"),
-                        autoescape=select_autoescape()
-                    )
-                    template = env.from_string(p)
-                    p = template.render(**v)
             else:
                 p = s.content
+            if s.jinja:
+                    from jinja2 import Environment, BaseLoader
+                    env = Environment(loader=BaseLoader)
+                    template = env.from_string(p)
+                    p = template.render(**v)
             create_list.append((s.filename, p, role))
         return create_list
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ install_requires=[
     'pygtrie',
     'packaging',
     'importlib_metadata',
-    'npf-web-extension >= 0.6.4'
+    'npf-web-extension >= 0.6.4',
+    'jinja2'
         ]
 
 setuptools.setup(


### PR DESCRIPTION
Allow to use jinja syntax in files.

E.g: This script would launch an amount (the variable CPU) of iperf server :
```
%variables
CPU=8

%file launch_iperf.sh jinja
{% for C in range($CPU) %}
iperf -s -p {{ 5000 + C}} &
{% endfor %}
wait
```

For now only in %file, but there's no reason not to add support for %script too

