### PR TITLE
fixed "nic" keyword behaviour when the same server is used for multiple roles

### DIFF
--- a/npf/cluster/node.py
+++ b/npf/cluster/node.py
@@ -192,8 +192,6 @@ class Node:
         if path is None:
             path = os.path.abspath(npf.globals.experiment_path())
         node = cls._nodes.get(addr, None)
-        if node is not None:
-            return node
         sshex = SSHExecutor(user, addr, path, port)
 
         node = Node(addr, sshex, options.tags)


### PR DESCRIPTION
Fixes #76. Now for each role a new SSH connection is used, even if a single machine has multiple roles. 