### PR TITLE
New CONCAT variable to merge multiple variables and ranges

### DIFF
--- a/npf/models/variables/ParentVariable.py
+++ b/npf/models/variables/ParentVariable.py
@@ -1,0 +1,28 @@
+from npf.models.units import get_numeric
+from npf.models.variables.ListVariable import ListVariable
+from npf.models.variables.variable import Variable
+from npf.models.units import dtype
+
+
+class ParentVariable(Variable):
+    """Variable with just a value
+    """
+    def __init__(self, name, children):
+        super().__init__(name)
+        self.children = children
+
+
+    def makeValues(self):
+        l = []
+        for c in self.children:
+            l.extend(c.makeValues())
+        return l
+
+    def count(self):
+        return sum([c.count() for c in self.children])
+
+    def format(self):
+        return self.name, [c.format() for c in self.children]
+
+    def is_numeric(self):
+        return all([c.is_numeric() for c in self.children])

--- a/npf/models/variables/VariableFactory.py
+++ b/npf/models/variables/VariableFactory.py
@@ -1,4 +1,5 @@
 from npf.models.units import get_numeric
+from npf.models.variables.ParentVariable import ParentVariable
 from npf.models.variables.DictVariable import DictVariable
 from npf.models.variables.ExpandVariable import ExpandVariable
 from npf.models.variables.HeadVariable import HeadVariable
@@ -10,8 +11,6 @@ from npf.models.variables.SimpleVariable import SimpleVariable
 
 
 import regex
-
-
 import re
 
 
@@ -35,8 +34,12 @@ class VariableFactory:
         result = regex.match("EXPAND\((.*)\)", valuedata)
         if result:
             if vsection is None:
-                raise Exception("RANDOM variable without vsection",vsection)
+                raise Exception("EXPAND variable without vsection",vsection)
             return ExpandVariable(name, result.group(1), vsection)
+
+        result = regex.match("CONCAT\((.*),(.*)\)", valuedata)
+        if result:
+            return ParentVariable(name, [VariableFactory.build(name,result.group(1),vsection), VariableFactory.build(name,result.group(2),vsection)])
 
         result = regex.match("RANDOM[ ]*\([ ]*([^,]+)[ ]*,[ ]*([^,]+)[ ]*\)", valuedata)
         if result:


### PR DESCRIPTION
For example :

N=CONCAT(1,[1000-8000#1000])

Allows to have N be either 1, 1000 , 2000 ... 8000

Useful for that very case where you want multiple of "1000", and you want a base case that is slightly different. Or for numbers of CPU usually uou want 1 but then maybe every pair CPU:

CPU=CONCAT(1,[2-16#2])

1,3,5..16 would be odd. 1,2,4,...16 makes much more sense

Poke @cdelzotti @maxvanliefde @ntyunyayev  I think we discussed that. One of you could get as a small starting point to have a more robust parsing (currently any comma in one of the subvariable will break the behavior) and allow more than two variables.